### PR TITLE
Add feature to skip beam delay test

### DIFF
--- a/mkat_fpga_tests/test_cbf.py
+++ b/mkat_fpga_tests/test_cbf.py
@@ -1249,15 +1249,26 @@ class test_CBF(unittest.TestCase, LoggingClass, AqfReporter, UtilsClass):
     @aqf_vr("CBF.V.A.IF")
     def test_beam_delay(self):
         Aqf.procedure(TestProcedure.GroupDelay)
+        reply, informs = self.katcp_req.capture_list()
+        self.assertTrue(reply.reply_ok())
+        beams = []
+        for msg in informs:
+            if 'tied' in msg.arguments[0]:
+                beams.append(msg.arguments[0])
+        #import IPython; IPython.embed()
         if 'skipped_test' in test_CBF.__dict__['test_beam_delay'].__dict__:
             self.Note('Mark test as skipped.')
             Aqf.skipped('Test skipped')
         elif 'tbd' in test_CBF.__dict__['test_beam_delay'].__dict__:
             self.Note('Mark test as tbd.')
             Aqf.tbd('Test tbd')
+        elif len(beams) < 3:
+            self.Note('Current running instrument does not contain multiple beams. Mark test as skipped.')
+            Aqf.skipped('Test skipped')
         else:
             try:
                 assert evaluate(os.getenv("DRY_RUN", "False"))
+                
             except AssertionError:
                 instrument_success = self.set_instrument(start_receiver = False)
                 if instrument_success:


### PR DESCRIPTION
This adds a feature to skip the beam delay test if multiple beams
are not included in the current running instrument and bitstream.